### PR TITLE
Add Terraform ~> 1.1.0 support - Version 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## 1.1.0 (2021-12-09)
+
+NEW FEATURES:
+
+* add support for Terraform version `~> 1.1.0`
+* Update lib/terradactyl/terraform/commands/destroy.rb (add Rev1_01)
+* Update lib/terradactyl/terraform/commands/init.rb (add Rev1_01)
+* Update spec/fixtures/stacks (add rev1_01)
+* Update spec/helpers.rb (add rev1_01 and lock rev1_00 to 1.0.11)
+
 ## 1.0.0 (2021-06-09)
 
 NEW FEATURES:

--- a/lib/terradactyl/terraform/commands/destroy.rb
+++ b/lib/terradactyl/terraform/commands/destroy.rb
@@ -56,6 +56,12 @@ module Terradactyl
       end
     end
 
+    module Rev1_01
+      module Destroy
+        include Terradactyl::Terraform::Rev015::Destroy
+      end
+    end
+
     module Commands
       class Destroy < Base
       end

--- a/lib/terradactyl/terraform/commands/init.rb
+++ b/lib/terradactyl/terraform/commands/init.rb
@@ -53,6 +53,12 @@ module Terradactyl
       end
     end
 
+    module Rev1_01
+      module Init
+        include Terradactyl::Terraform::Rev015::Init
+      end
+    end
+
     module Commands
       class Init < Base
       end

--- a/lib/terradactyl/terraform/planfile.rb
+++ b/lib/terradactyl/terraform/planfile.rb
@@ -103,6 +103,11 @@ module Terradactyl
       end
     end
 
+    module Rev1_01
+      class PlanFileParser < Rev012::PlanFileParser
+      end
+    end
+
     module Rev011
       class PlanFileParser < Rev012::PlanFileParser
         def checksum

--- a/lib/terradactyl/terraform/version.rb
+++ b/lib/terradactyl/terraform/version.rb
@@ -2,6 +2,6 @@
 
 module Terradactyl
   module Terraform
-    VERSION = '1.0.0'
+    VERSION = '1.1.0'
   end
 end

--- a/spec/fixtures/stacks/rev1_01/test.tf
+++ b/spec/fixtures/stacks/rev1_01/test.tf
@@ -1,0 +1,6 @@
+provider "null" {
+}
+
+resource "null_resource" "foo" {
+}
+

--- a/spec/fixtures/stacks/rev1_01/versions.tf
+++ b/spec/fixtures/stacks/rev1_01/versions.tf
@@ -1,0 +1,10 @@
+
+terraform {
+  required_version = "~> 1.1.0"
+  required_providers {
+    null = {
+      version = "~> 3.0"
+      source  = "hashicorp/null"
+    }
+  }
+}

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -65,8 +65,8 @@ module Helpers
           }
         },
         rev1_00: {
-          version: '~> 1.0.0',
-          plan_checksum: '0bd24348ff74045ee166f5928a0ea980aeba07ab',
+          version: '1.0.11',
+          plan_checksum: '4f706dc6e0b9a7c5a4ecc31f34d879f18f49f28f',
           artifacts: {
             init:    '.terraform',
             lock:    '.terraform.lock.hcl',
@@ -77,6 +77,20 @@ module Helpers
             lint:    'unlinted.tf',
           }
         },
+        rev1_01: {
+          version: '~> 1.1.0',
+          plan_checksum: 'c3767566118abc9d237024034d0aebcbaf63d1f3',
+          artifacts: {
+            init:    '.terraform',
+            lock:    '.terraform.lock.hcl',
+            plan:    'rev1_01.tfout',
+            apply:   'terraform.tfstate',
+            refresh: 'terraform.tfstate',
+            destroy: 'terraform.tfstate',
+            lint:    'unlinted.tf',
+          }
+        },
+
       }
     end
   end


### PR DESCRIPTION
Update lib/terradactyl/terraform/commands/destroy.rb (add Rev1_01)
Update lib/terradactyl/terraform/commands/init.rb (add Rev1_01)
Update spec/fixtures (add rev1_01)
Update spec/helpers.rb (add rev1_01 and lock rev1_00 to 1.0.11)