### PR TITLE
Release 1.1.3 - download_url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 1.1.3 (2022-01-05)
+
+BUG FIXES:
+
+* Add back `download_url` def block
+
 ## 1.1.2 (2022-01-03)
 
 BUG FIXES:

--- a/lib/terradactyl/terraform/version.rb
+++ b/lib/terradactyl/terraform/version.rb
@@ -2,6 +2,6 @@
 
 module Terradactyl
   module Terraform
-    VERSION = '1.1.2'
+    VERSION = '1.1.3'
   end
 end

--- a/lib/terradactyl/terraform/version_manager/package.rb
+++ b/lib/terradactyl/terraform/version_manager/package.rb
@@ -36,6 +36,10 @@ module Terradactyl
           end
         end
 
+        def downloads_url
+          VersionManager.downloads_url
+        end
+
         def releases_url
           VersionManager.releases_url
         end


### PR DESCRIPTION
BUG FIXES:

* Add back `download_url` def block