### PR TITLE
Add Terraform ~> 1.2.0 support - Version 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## 1.2.0 (2022-05-18)
+
+NEW FEATURES:
+
+* add support for Terraform version `~> 1.2.0`
+* Update lib/terradactyl/terraform/commands/destroy.rb (add Rev1_02)
+* Update lib/terradactyl/terraform/commands/init.rb (add Rev1_02)
+* Update spec/fixtures/stacks (add rev1_02)
+* Update spec/helpers.rb (add rev1_02)
+
 ## 1.1.2 (2022-01-03)
 
 BUG FIXES:

--- a/lib/terradactyl/terraform/commands/destroy.rb
+++ b/lib/terradactyl/terraform/commands/destroy.rb
@@ -62,6 +62,12 @@ module Terradactyl
       end
     end
 
+    module Rev1_02
+      module Destroy
+        include Terradactyl::Terraform::Rev015::Destroy
+      end
+    end
+
     module Commands
       class Destroy < Base
       end

--- a/lib/terradactyl/terraform/commands/init.rb
+++ b/lib/terradactyl/terraform/commands/init.rb
@@ -59,6 +59,12 @@ module Terradactyl
       end
     end
 
+    module Rev1_02
+      module Init
+        include Terradactyl::Terraform::Rev015::Init
+      end
+    end
+
     module Commands
       class Init < Base
       end

--- a/lib/terradactyl/terraform/planfile.rb
+++ b/lib/terradactyl/terraform/planfile.rb
@@ -108,6 +108,11 @@ module Terradactyl
       end
     end
 
+    module Rev1_02
+      class PlanFileParser < Rev012::PlanFileParser
+      end
+    end
+
     module Rev011
       class PlanFileParser < Rev012::PlanFileParser
         def checksum

--- a/lib/terradactyl/terraform/version.rb
+++ b/lib/terradactyl/terraform/version.rb
@@ -2,6 +2,6 @@
 
 module Terradactyl
   module Terraform
-    VERSION = '1.1.2'
+    VERSION = '1.2.0'
   end
 end

--- a/spec/fixtures/stacks/rev1_02/test.tf
+++ b/spec/fixtures/stacks/rev1_02/test.tf
@@ -1,0 +1,6 @@
+provider "null" {
+}
+
+resource "null_resource" "foo" {
+}
+

--- a/spec/fixtures/stacks/rev1_02/versions.tf
+++ b/spec/fixtures/stacks/rev1_02/versions.tf
@@ -1,0 +1,10 @@
+
+terraform {
+  required_version = "~> 1.2.0"
+  required_providers {
+    null = {
+      version = "~> 3.0"
+      source  = "hashicorp/null"
+    }
+  }
+}

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -90,6 +90,19 @@ module Helpers
             lint:    'unlinted.tf',
           }
         },
+        rev1_02: {
+          version: '1.2.0',
+          plan_checksum: '53f1cf9d6ddf2357a860c8bcf6ef53e53c97bd50',
+          artifacts: {
+            init:    '.terraform',
+            lock:    '.terraform.lock.hcl',
+            plan:    'rev1_02.tfout',
+            apply:   'terraform.tfstate',
+            refresh: 'terraform.tfstate',
+            destroy: 'terraform.tfstate',
+            lint:    'unlinted.tf',
+          }
+        },
       }
     end
   end


### PR DESCRIPTION
NEW FEATURES:

* add support for Terraform version `~> 1.2.0`
* Update lib/terradactyl/terraform/commands/destroy.rb (add Rev1_02)
* Update lib/terradactyl/terraform/commands/init.rb (add Rev1_02)
* Update spec/fixtures/stacks (add rev1_02)
* Update spec/helpers.rb (add rev1_02)