### PR TITLE
Release 1.2.1 - Fix binary downloader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ Gemfile.lock
 /spec/reports/
 /tmp/
 vendor
+.DS_Store
 
 # rspec failure tracking
 .rspec_status

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGELOG
 
+## 1.2.1 (2022-06-13)
+
+BUG FIX:
+
+* differentiate between `arm` and `arm64` architectures
+  * fixes binary downloader on Apple silicon
+
+MISCELLANEOUS: 
+
+* Add `.DS_Store` to `.gitignore`
+
 ## 1.2.0 (2022-05-18)
 
 NEW FEATURES:

--- a/lib/terradactyl/terraform/version.rb
+++ b/lib/terradactyl/terraform/version.rb
@@ -2,6 +2,6 @@
 
 module Terradactyl
   module Terraform
-    VERSION = '1.2.0'
+    VERSION = '1.2.1'
   end
 end

--- a/lib/terradactyl/terraform/version_manager/package.rb
+++ b/lib/terradactyl/terraform/version_manager/package.rb
@@ -10,8 +10,10 @@ module Terradactyl
             'amd64'
           when /i?86|x86|i86pc/
             '386'
-          when /^arm/
+          when /^arm$/
             'arm'
+          when /^arm64/
+            'arm64'
           else
             raise "FATAL: Unsupported CPU arch, #{value}"
           end


### PR DESCRIPTION
* differentiate between `arm` and `arm64` architectures
  * fixes binary downloader on Apple silicon
* Add `.DS_Store` to `.gitignore`